### PR TITLE
Make compile under Ubuntu20.04

### DIFF
--- a/slam3d/core/CMakeLists.txt
+++ b/slam3d/core/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(core
 		$<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(core PUBLIC Eigen3::Eigen ${FLANN_LIBRARIES})
+target_link_libraries(core PUBLIC Eigen3::Eigen ${FLANN_LIBRARIES} lz4)
 
 target_compile_features(core PUBLIC cxx_alias_templates)
 

--- a/slam3d/core/Types.hpp
+++ b/slam3d/core/Types.hpp
@@ -29,6 +29,7 @@
 #include <sys/time.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include <boost/shared_ptr.hpp>
 #include <Eigen/Geometry>
 
 #include <string>


### PR DESCRIPTION
First commit is straight forward.

second commit:
```
 38%] Linking CXX executable test_boost_graph
/usr/bin/ld: ../../core/libslam3d_core.so: undefined reference to `LZ4_decompress_safe_continue'
/usr/bin/ld: ../../core/libslam3d_core.so: undefined reference to `LZ4_decompress_safe'
/usr/bin/ld: ../../core/libslam3d_core.so: undefined reference to `LZ4_compress_HC_continue'
/usr/bin/ld: ../../core/libslam3d_core.so: undefined reference to `LZ4_resetStreamHC'
/usr/bin/ld: ../../core/libslam3d_core.so: undefined reference to `LZ4_setStreamDecode'
collect2: error: ld returned 1 exit status
make[2]: *** [slam3d/graph/boost/CMakeFiles/test_boost_graph.dir/build.make:91: slam3d/graph/boost/test_boost_graph] Error 1
make[1]: *** [CMakeFiles/Makefile2:282: slam3d/graph/boost/CMakeFiles/test_boost_graph.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
The dependency to lz4 comes from flann. If flann was integrated via pkg-config the missing dependency would be passed correctly.

```bash
pkg-config --libs flann
-llz4 -lflann -lflann_cpp
```

Since pkg-config was not used in any CMakeLists.txt in this project and the dependency to flann comes somehow via pcl, I refrained to use it here.


