### PR TITLE
For jsoncpp, fall back to pkgconfig if cmake config fails

### DIFF
--- a/slam3d-dependencies.cmake
+++ b/slam3d-dependencies.cmake
@@ -10,7 +10,10 @@ endif ()
 find_package(Boost REQUIRED COMPONENTS thread graph unit_test_framework)
 find_package(PCL 1.7 REQUIRED COMPONENTS registration sample_consensus)
 find_package(g2o REQUIRED)
-find_package(jsoncpp REQUIRED)
+find_package(jsoncpp)
+if (NOT jsoncpp_FOUND)
+  pkg_check_modules(jsoncpp REQUIRED IMPORTED_TARGET jsoncpp)
+endif()
 
 pkg_check_modules(flann REQUIRED IMPORTED_TARGET flann)
 

--- a/slam3d/sensor/rtls_flares/CMakeLists.txt
+++ b/slam3d/sensor/rtls_flares/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(sensor-rtls
 )
 
 target_link_libraries(sensor-rtls
-	PUBLIC core jsoncpp_lib
+	PUBLIC core jsoncpp
 )
 
 # Install header files


### PR DESCRIPTION
This is only tested with the pkgconfig variant, please test that this works when cmake provides the dependency.