### PR TITLE
reset `mReference` before recalculating it in `setReference`

### DIFF
--- a/slam3d/sensor/gdal/CoordTransformer.cpp
+++ b/slam3d/sensor/gdal/CoordTransformer.cpp
@@ -41,5 +41,6 @@ Position CoordTransformer::toUTM(ScalarType lon, ScalarType lat, ScalarType alt)
 
 void CoordTransformer::setReference(ScalarType lon, ScalarType lat, ScalarType alt)
 {
+	mReference.setZero();
 	mReference = toUTM(lon, lat, alt);
 }


### PR DESCRIPTION
Without this fix, changing setting the reference a second time will act not as expected (e.g., when setting the same reference twice, the second time `toUTM` calculates a zero offset, which basically resets the offset even though it should stay the same).
