### PR TITLE
Omit PCL version suffix starting with PCL version 1.14.

### DIFF
--- a/slam3d/sensor/pcl/CMakeLists.txt
+++ b/slam3d/sensor/pcl/CMakeLists.txt
@@ -41,6 +41,10 @@ install(TARGETS sensor-pcl EXPORT slam3d-targets
 )
 
 # Install pkg-config file
+# Before version 1.14 pkg-config files of PCL had a version suffix.
+IF("${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}" VERSION_LESS 1.14)
+    SET(PCL_VERSION_SUFFIX "-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
+ENDIF()
 configure_file(slam3d_sensor_pcl.pc.in slam3d_sensor_pcl.pc @ONLY)
 install(
 	FILES ${PROJECT_BINARY_DIR}/slam3d/sensor/pcl/slam3d_sensor_pcl.pc

--- a/slam3d/sensor/pcl/slam3d_sensor_pcl.pc.in
+++ b/slam3d/sensor/pcl/slam3d_sensor_pcl.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: slam3d_sensor_pcl
 Description: Sensor module to handle pointclouds using PCL.
 Version: @SLAM3D_VERSION@
-Requires: slam3d_core pcl_registration-@PCL_VERSION_MAJOR@.@PCL_VERSION_MINOR@
+Requires: slam3d_core pcl_registration@PCL_VERSION_SUFFIX@
 Libs: -L${libdir} -lslam3d_sensor_pcl
 Cflags: -I${includedir}


### PR DESCRIPTION
Required for Ubuntu 24 compatibility