### PR TITLE
allow to set the initial index id (in case a database already has a graph)

### DIFF
--- a/slam3d/core/Types.hpp
+++ b/slam3d/core/Types.hpp
@@ -92,7 +92,7 @@ namespace slam3d
 	class Indexer
 	{
 	public:
-		Indexer():mNextID(1) {}
+		Indexer(const IdType& firstID = 1):mNextID(firstID) {}
 		IdType getNext() { return mNextID++; }
 	private:
 		IdType mNextID;


### PR DESCRIPTION
In case an existing graph is used (from a database), the initial vertexid must be set before adding new vertices