### PR TITLE
allow pause on saving clouds

### DIFF
--- a/slam3d/core/MeasurementStorage.cpp
+++ b/slam3d/core/MeasurementStorage.cpp
@@ -1,4 +1,4 @@
-#include "MeasurementStorage.hpp"
+﻿#include "MeasurementStorage.hpp"
 
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
@@ -7,12 +7,19 @@ using namespace slam3d;
 
 void MeasurementStorage::add(Measurement::Ptr measurement)
 {
-	mMeasurements[measurement->getUniqueId()] = measurement;
+	if (enabled) {
+		mMeasurements[measurement->getUniqueId()] = measurement;
+	}
+
 }
 
 Measurement::Ptr MeasurementStorage::get(const boost::uuids::uuid& uuid)
 {
-	return mMeasurements.at(uuid);
+	try {
+		return mMeasurements.at(uuid);
+	}catch (const std::out_of_range& e) {
+		return Measurement::Ptr();
+	}
 }
 
 Measurement::Ptr MeasurementStorage::get(const std::string& key)
@@ -23,4 +30,14 @@ Measurement::Ptr MeasurementStorage::get(const std::string& key)
 bool MeasurementStorage::contains(const boost::uuids::uuid& key)
 {
 	return mMeasurements.count(key);
+}
+
+void MeasurementStorage::enable()
+{
+	enabled = true;
+}
+
+void MeasurementStorage::disable()
+{
+	enabled = false;
 }

--- a/slam3d/core/MeasurementStorage.hpp
+++ b/slam3d/core/MeasurementStorage.hpp
@@ -15,7 +15,7 @@ namespace slam3d
 	class MeasurementStorage
 	{
 	public:
-
+		MeasurementStorage():enabled(true) {}
 		virtual ~MeasurementStorage() {}
 
 		/**
@@ -46,6 +46,12 @@ namespace slam3d
 		 * @throws boost::bad_lexical_cast if the given string is no valid UUID
 		 */
 		Measurement::Ptr get(const std::string& key);
+
+		void enable();
+		void disable();
+
+	protected:
+		bool enabled;
 
 	private:
 		std::map<boost::uuids::uuid, Measurement::Ptr> mMeasurements;

--- a/slam3d/sensor/pcl/PointCloudSensor.cpp
+++ b/slam3d/sensor/pcl/PointCloudSensor.cpp
@@ -122,6 +122,11 @@ Transform align(PointCloudMeasurement::Ptr source,
 	// Downsample the scans
 	PointCloud::Ptr filtered_source = source->getPointCloud();
 	PointCloud::Ptr filtered_target = target->getPointCloud();
+
+	if (!filtered_source || !filtered_target) {
+		return Transform::Identity();
+	}
+
 	if(config.point_cloud_density > 0)
 	{
 		filtered_source = PointCloudSensor::downsample(source->getPointCloud(), config.point_cloud_density);
@@ -226,10 +231,11 @@ PointCloud::Ptr PointCloudSensor::getAccumulatedCloud(const VertexObjectList& ve
 	{
 		Measurement::Ptr m = mMapper->getGraph()->getMeasurement(vertices[i].measurementUuid);
 		PointCloudMeasurement::Ptr pcl = boost::dynamic_pointer_cast<PointCloudMeasurement>(m);
-		if(!pcl)
+		if(!pcl || pcl->getPointCloud()->size() == 0)
 		{
-			mLogger->message(ERROR, "Measurement in getAccumulatedCloud() is not a point cloud!");
-			throw BadMeasurementType();
+			mLogger->message(ERROR, "Measurement in getAccumulatedCloud() is not available or not a point cloud!");
+			// throw BadMeasurementType();
+			continue;
 		}
 		
 		PointCloud::Ptr tempCloud = transform(pcl->getPointCloud(), (vertices[i].correctedPose * pcl->getSensorPose()));
@@ -261,10 +267,13 @@ Constraint::Ptr PointCloudSensor::createConstraint(const Measurement::Ptr& sourc
 	// Cast to this sensors measurement type
 	PointCloudMeasurement::Ptr sourceCloud = boost::dynamic_pointer_cast<PointCloudMeasurement>(source);
 	PointCloudMeasurement::Ptr targetCloud = boost::dynamic_pointer_cast<PointCloudMeasurement>(target);
-	if(!sourceCloud || !targetCloud)
+	if((!sourceCloud || !targetCloud) || sourceCloud->getPointCloud()->size() == 0 || targetCloud->getPointCloud()->size() == 0)
 	{
 		mLogger->message(ERROR, "Measurement given to createConstraint() is not a PointCloud!");
-		throw BadMeasurementType();
+		// throw BadMeasurementType();
+		// is there was an emptyx cloud, use the guess
+		Covariance<6> covariance = Covariance<6>::Identity() * mCovarianceScale;
+		return Constraint::Ptr(new SE3Constraint(mName, guess, covariance.inverse()));
 	}
 	
 	// For large loops, refine guess by a coarse ICP


### PR DESCRIPTION
This allows to call (disable) in a storage implementation, so that e.g. point clouds are not actually saved, the contraint is still created, but the cloud is not saved. On enable() the initial guess is trusted and mapping can go on.