### PR TITLE
replace Graph::getNearbyVertices() with non-kdtree version 

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -14,7 +14,6 @@
   <depend package="restcpp" optional="1"/>
   <depend package="suitesparse" />
   <depend package="jsoncpp" />
-  <depend package="flann" />
   
   <keywords>
     <keyword>Mapping</keyword>

--- a/slam3d-dependencies.cmake
+++ b/slam3d-dependencies.cmake
@@ -20,8 +20,6 @@ if (NOT jsoncpp_FOUND)
   endif()
 endif()
 
-pkg_check_modules(flann REQUIRED IMPORTED_TARGET flann)
-
 # Optional libraries
 find_package(libpointmatcher 1.3.1)
 find_package(GDAL)

--- a/slam3d/core/CMakeLists.txt
+++ b/slam3d/core/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(core
 		Eigen3::Eigen
 		Boost::thread
 		Boost::serialization
-		PkgConfig::flann)
+)
 
 target_compile_features(core PUBLIC cxx_alias_templates)
 

--- a/slam3d/core/Graph.cpp
+++ b/slam3d/core/Graph.cpp
@@ -260,11 +260,13 @@ const VertexObjectList Graph::getNearbyVertices(const Transform &tf, float radiu
 
 	// reserve space for all vertices (to avoid memory allocation during push_back calls)
 	result.reserve(allVertices.size());
-
-	for (const auto& vertex : allVertices) {
-		if (sensors.empty() || sensors.count(vertex.typeName)) {
+	for (const auto& vertex : allVertices)
+	{
+		if (sensors.empty() || sensors.count(vertex.sensorName))
+		{
 			double d = (vertex.correctedPose.translation()-tf.translation()).norm();
-			if (d < radius) {
+			if (d < radius)
+			{
 				result.push_back(vertex);
 				mLogger->message(DEBUG, (boost::format(" - vertex %1% nearby (d = %2%)") % vertex.index % d).str());
 			}

--- a/slam3d/core/Graph.hpp
+++ b/slam3d/core/Graph.hpp
@@ -1,4 +1,4 @@
-// slam3d - Frontend for graph-based SLAM
+﻿// slam3d - Frontend for graph-based SLAM
 // Copyright (C) 2017 S. Kasperski
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,14 +77,11 @@ laser->addMeasurement(m);
 #include <slam3d/core/Solver.hpp>
 #include <slam3d/core/MeasurementStorage.hpp>
 
-#include <flann/flann.hpp>
 #include <map>
 #include <set>
 
 namespace slam3d
 {
-	typedef flann::Index< flann::L2<float> > NeighborIndex;
-	
 	/**
 	 * @class InvalidVertex
 	 * @brief Exception thrown when a vertex ID does not exist in the graph.
@@ -298,22 +295,14 @@ namespace slam3d
 		virtual void writeGraphToFile(const std::string &name);
 
 		/**
-		 * @brief Create the index for nearest neighbor search of nodes.
-		 * @param sensors index nodes of these sensors
-		 */
-		virtual void buildNeighborIndex(const std::set<std::string>& sensors = std::set<std::string>());
-
-		/**
-		 * @brief Search for nodes in the graph near the given pose.
-		 * @details This does not refer to a NN-Search in the graph, but to search for
-		 * spatially near poses according to their current corrected pose.
-		 * If new nodes have been added, the index has to be created with
-		 * a call to buildNeighborIndex.
+		 * @brief Search for nodes in the graph near the given pose, filtered by sensors.
+		 * @example For sensor types, you can use a initializer list to shorten you code: getNearbyVertices(location, radius, {"slam3d::PointCloudMeasurement"});
 		 * @param tf The pose where to search for nodes
 		 * @param radius The radius within nodes should be returned
+		 * @param sensors sensor types to include
 		 * @return list of spatially near vertices
 		 */
-		virtual const VertexObjectList getNearbyVertices(const Transform &tf, float radius, const std::string& sensortype = "") const;
+		virtual const VertexObjectList getNearbyVertices(const Transform &tf, float radius, const std::set<std::string>& sensors = std::set<std::string>()) const;
 
 		/**
 		 * @brief Gets the index of the vertex with the given Measurement
@@ -484,13 +473,6 @@ namespace slam3d
 		// Index to find Vertices by the unique id of their measurement
 		typedef std::map<boost::uuids::uuid, IdType> UuidIndex;
 		UuidIndex mUuidIndex;
-
-		// Index to use nearest neighbor search
-		// Whenever this index is created, we have to enumerate all vertices from 0 to n-1.
-		// This mapping is kept in a separate map to later apply the result to the graph.
-		flann::SearchParams mSearchParams;
-		NeighborIndex mNeighborIndex;
-		std::map<IdType, IdType> mNeighborMap; // vertex-id --> neighbor-id
 
 		// Parameters
 		bool mFixNext;

--- a/slam3d/core/ScanSensor.cpp
+++ b/slam3d/core/ScanSensor.cpp
@@ -172,9 +172,8 @@ void ScanSensor::linkToNeighbors(IdType vertex)
 	if(mMaxNeighorLinks == 0)
 		return;
 
-	mMapper->getGraph()->buildNeighborIndex(mLinkSensors);
 	VertexObject obj = mMapper->getGraph()->getVertex(vertex);
-	VertexObjectList neighbors = mMapper->getGraph()->getNearbyVertices(obj.correctedPose, mNeighborRadius);
+	VertexObjectList neighbors = mMapper->getGraph()->getNearbyVertices(obj.correctedPose, mNeighborRadius, mLinkSensors);
 	
 	int count = 0;
 	for(auto i = neighbors.rbegin(); i != neighbors.rend() && count < mMaxNeighorLinks; i++)

--- a/slam3d/core/slam3d_core.pc.in
+++ b/slam3d/core/slam3d_core.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: slam3d_core
 Description: Core components of the SLAM3D library.
 Version: @SLAM3D_VERSION@
-Requires: eigen3 flann
+Requires: eigen3
 Libs: -L${libdir} -lslam3d_core -lboost_thread
 Cflags: -I${includedir}


### PR DESCRIPTION
Is seems for me that getNearbyVertices() in the flann version does not return all vertices for a large radius request.

This PR replaces the kd-tree version with a local linear search, which hopefully also has a better performance as the kd-tree, because does not have to be rebuild the index at all.