### PR TITLE
WIP: Cleanup of graph interface

### DIFF
--- a/slam3d/core/Graph.cpp
+++ b/slam3d/core/Graph.cpp
@@ -252,24 +252,21 @@ Measurement::Ptr Graph::getMeasurement(boost::uuids::uuid id)
 	return mStorage->get(id);
 }
 
-const VertexObjectList Graph::getNearbyVertices(const Transform &tf, float radius, const std::set<std::string>& sensors) const
+const VertexObjectList Graph::getNearbyVertices(const Transform &tf, float radius, const StringSet& sensors) const
 {
 	// get Vertex list from specific graph implementation
-	VertexObjectList allVertices = getAllVertices();
+	VertexObjectList allVertices = getVerticesFromSensor(sensors);
 	VertexObjectList result;
 
 	// reserve space for all vertices (to avoid memory allocation during push_back calls)
 	result.reserve(allVertices.size());
 	for (const auto& vertex : allVertices)
 	{
-		if (sensors.empty() || sensors.count(vertex.sensorName))
+		double d = (vertex.correctedPose.translation()-tf.translation()).norm();
+		if (d < radius)
 		{
-			double d = (vertex.correctedPose.translation()-tf.translation()).norm();
-			if (d < radius)
-			{
-				result.push_back(vertex);
-				mLogger->message(DEBUG, (boost::format(" - vertex %1% nearby (d = %2%)") % vertex.index % d).str());
-			}
+			result.push_back(vertex);
+			mLogger->message(DEBUG, (boost::format(" - vertex %1% nearby (d = %2%)") % vertex.index % d).str());
 		}
 	}
 	// free leftover memory

--- a/slam3d/core/Graph.cpp
+++ b/slam3d/core/Graph.cpp
@@ -64,7 +64,7 @@ void Graph::reloadToSolver()
 	mSolver->clear();
 
 	// add all vertices 
-	VertexObjectList vertices = getAllVertices();
+	VertexObjectList vertices = getVertices();
 	for (const auto& vertex : vertices)
 	{
 		mSolver->addVertex(vertex.index, vertex.correctedPose);
@@ -222,26 +222,6 @@ const Transform Graph::getTransform(IdType source, IdType target) const
 	return getVertex(source).correctedPose.inverse() * getVertex(target).correctedPose;
 }
 
-const std::set<std::string> Graph::getVertexSensors() const
-{
-	std::set<std::string> sensors;
-	for (const auto& vertex : getAllVertices())
-	{
-		sensors.insert(vertex.sensorName);
-	}
-	return sensors;
-}
-
-const std::set<std::string> Graph::getEdgeSensors() const
-{
-	std::set<std::string> sensors;
-	for (const auto& edge : getEdges(getAllVertices()))
-	{
-		sensors.insert(edge.constraint->getSensorName());
-	}
-	return sensors;
-}
-
 Measurement::Ptr Graph::getMeasurement(IdType id)
 {
 	return mStorage->get(getVertex(id).measurementUuid);
@@ -252,10 +232,15 @@ Measurement::Ptr Graph::getMeasurement(boost::uuids::uuid id)
 	return mStorage->get(id);
 }
 
+const VertexObjectList Graph::getVerticesFromSensor(const std::string& sensor) const
+{
+	return getVertices({sensor});
+}
+
 const VertexObjectList Graph::getNearbyVertices(const Transform &tf, float radius, const StringSet& sensors) const
 {
 	// get Vertex list from specific graph implementation
-	VertexObjectList allVertices = getVerticesFromSensor(sensors);
+	VertexObjectList allVertices = getVertices(sensors);
 	VertexObjectList result;
 
 	// reserve space for all vertices (to avoid memory allocation during push_back calls)

--- a/slam3d/core/Graph.hpp
+++ b/slam3d/core/Graph.hpp
@@ -326,7 +326,7 @@ namespace slam3d
 		 * @param id uuid of a measurement
 		 * @return constant reference to a vertex
 		 */
-		const VertexObject getVertex(boost::uuids::uuid id) const;
+		virtual const VertexObject getVertex(boost::uuids::uuid id) const;
 
 		/**
 		 * @brief Get a measurement for a given vertex id. 

--- a/slam3d/core/Graph.hpp
+++ b/slam3d/core/Graph.hpp
@@ -375,19 +375,25 @@ namespace slam3d
 		 * @brief Get a list of sensors that created vertices within the graph
 		 * @return list of sensor names 
 		 */
-		virtual const StringSet getVertexSensors() const;
+		virtual const StringSet getVertexSensors() const = 0;
 
 		/**
 		 * @brief Get a list of sensors that created edges within the graph
 		 * @return list of sensor names 
 		 */
-		virtual const StringSet getEdgeSensors() const;
+		virtual const StringSet getEdgeSensors() const = 0;
 
 		/**
 		 * @brief Gets a list of all vertices from given sensor.
 		 * @param sensor
 		 */
-		virtual const VertexObjectList getVerticesFromSensor(const StringSet& sensors = {}) const = 0;
+		const VertexObjectList getVerticesFromSensor(const std::string& sensor) const;
+
+		/**
+		 * @brief Gets a list of all vertices from given sensor.
+		 * @param sensor
+		 */
+		virtual const VertexObjectList getVertices(const StringSet& sensors = {}) const = 0;
 
 		/**
 		 * @brief Gets a list of all vertices with a given measurement type.

--- a/slam3d/core/Graph.hpp
+++ b/slam3d/core/Graph.hpp
@@ -78,7 +78,6 @@ laser->addMeasurement(m);
 #include <slam3d/core/MeasurementStorage.hpp>
 
 #include <map>
-#include <set>
 
 namespace slam3d
 {
@@ -296,13 +295,16 @@ namespace slam3d
 
 		/**
 		 * @brief Search for nodes in the graph near the given pose, filtered by sensors.
-		 * @example For sensor types, you can use a initializer list to shorten you code: getNearbyVertices(location, radius, {"slam3d::PointCloudMeasurement"});
+		 * @example getNearbyVertices(location, radius, {"FrontLaser"});
 		 * @param tf The pose where to search for nodes
 		 * @param radius The radius within nodes should be returned
-		 * @param sensors sensor types to include
+		 * @param sensors sensor names to include
 		 * @return list of spatially near vertices
 		 */
-		virtual const VertexObjectList getNearbyVertices(const Transform &tf, float radius, const std::set<std::string>& sensors = std::set<std::string>()) const;
+		virtual const VertexObjectList getNearbyVertices(
+			const Transform &tf,
+			float radius,
+			const StringSet& sensors = {}) const;
 
 		/**
 		 * @brief Gets the index of the vertex with the given Measurement
@@ -373,19 +375,19 @@ namespace slam3d
 		 * @brief Get a list of sensors that created vertices within the graph
 		 * @return list of sensor names 
 		 */
-		virtual const std::set<std::string> getVertexSensors() const;
+		virtual const StringSet getVertexSensors() const;
 
 		/**
 		 * @brief Get a list of sensors that created edges within the graph
 		 * @return list of sensor names 
 		 */
-		virtual const std::set<std::string> getEdgeSensors() const;
+		virtual const StringSet getEdgeSensors() const;
 
 		/**
 		 * @brief Gets a list of all vertices from given sensor.
 		 * @param sensor
 		 */
-		virtual const VertexObjectList getVerticesFromSensor(const std::string& sensor) const = 0;
+		virtual const VertexObjectList getVerticesFromSensor(const StringSet& sensors = {}) const = 0;
 
 		/**
 		 * @brief Gets a list of all vertices with a given measurement type.
@@ -400,12 +402,6 @@ namespace slam3d
 		 * @throw InvalidVertex
 		 */
 		virtual const VertexObjectList getVerticesInRange(IdType source, unsigned range) const = 0;
-
-		/**
-		 * @brief Get all Vertices in the graph.
-		 * @details Can be used to accumulate a global map from different sources, i.e. not all sensor names are known.
-		 */
-		virtual const VertexObjectList getAllVertices() const = 0;
 
 		/**
 		 * @brief Gets a list of all edges from given sensor.

--- a/slam3d/core/Types.hpp
+++ b/slam3d/core/Types.hpp
@@ -40,6 +40,7 @@
 
 #include <string>
 #include <vector>
+#include <set>
 
 
 namespace slam3d
@@ -51,6 +52,7 @@ namespace slam3d
 	typedef Eigen::Quaternion<ScalarType> Quaternion;
 	typedef Eigen::Transform<ScalarType,3,Eigen::Isometry> Transform;
 	template <unsigned N> using Covariance = Eigen::Matrix<ScalarType,N,N>;
+	typedef std::set<std::string> StringSet;
 }
 
 namespace boost

--- a/slam3d/core/test_templates/GraphTest.hpp
+++ b/slam3d/core/test_templates/GraphTest.hpp
@@ -90,7 +90,7 @@ void test_graph_construction(slam3d::Graph* graph)
 	BOOST_CHECK_EQUAL(hops, 2);
 
 	addVertexToGraph(graph, 4, "R2", "S1");
-	slam3d::VertexObjectList allVertices = graph->getAllVertices();
+	slam3d::VertexObjectList allVertices = graph->getVertices();
 	BOOST_CHECK_EQUAL(allVertices.size(), 4);
 
 

--- a/slam3d/graph/boost/BoostGraph.cpp
+++ b/slam3d/graph/boost/BoostGraph.cpp
@@ -91,13 +91,13 @@ void BoostGraph::removeEdge(IdType source, IdType target, const std::string& sen
 	boost::remove_edge(getEdgeIterator(source, target, sensor), mPoseGraph);
 }
 
-const VertexObjectList BoostGraph::getVerticesFromSensor(const std::string& sensor) const
+const VertexObjectList BoostGraph::getVerticesFromSensor(const StringSet& sensors) const
 {
 	VertexObjectList objectList;
 	VertexRange vertices = boost::vertices(mPoseGraph);
 	for(VertexIterator it = vertices.first; it != vertices.second; ++it)
 	{
-		if(mPoseGraph[*it].sensorName == sensor)
+		if(sensors.empty() || sensors.count(mPoseGraph[*it].sensorName))
 		{
 			objectList.push_back(mPoseGraph[*it]);
 		}
@@ -267,16 +267,6 @@ const VertexObjectList BoostGraph::getVerticesInRange(IdType source_id, unsigned
 		vertices.push_back(mPoseGraph[it->first]);
 	}
 	return vertices;
-}
-
-const VertexObjectList BoostGraph::getAllVertices() const
-{
-	VertexObjectList vertice_list;
-	vertice_list.reserve(num_vertices(mPoseGraph));
-	for (auto entry : boost::make_iterator_range(vertices(mPoseGraph))) {
-		vertice_list.push_back(mPoseGraph[entry]);
-	}
-	return vertice_list;
 }
 
 float BoostGraph::calculateGraphDistance(IdType source_id, IdType target_id) const

--- a/slam3d/graph/boost/BoostGraph.cpp
+++ b/slam3d/graph/boost/BoostGraph.cpp
@@ -91,7 +91,7 @@ void BoostGraph::removeEdge(IdType source, IdType target, const std::string& sen
 	boost::remove_edge(getEdgeIterator(source, target, sensor), mPoseGraph);
 }
 
-const VertexObjectList BoostGraph::getVerticesFromSensor(const StringSet& sensors) const
+const VertexObjectList BoostGraph::getVertices(const StringSet& sensors) const
 {
 	VertexObjectList objectList;
 	VertexRange vertices = boost::vertices(mPoseGraph);
@@ -117,6 +117,28 @@ const VertexObjectList BoostGraph::getVerticesByType(const std::string& type) co
 		}
 	}
 	return objectList;
+}
+
+const StringSet BoostGraph::getVertexSensors() const
+{
+	std::set<std::string> sensors;
+	VertexRange vertices = boost::vertices(mPoseGraph);
+	for(VertexIterator it = vertices.first; it != vertices.second; ++it)
+	{
+		sensors.insert(mPoseGraph[*it].sensorName);
+	}
+	return sensors;
+}
+
+const StringSet BoostGraph::getEdgeSensors() const
+{
+	std::set<std::string> sensors;
+	EdgeRange edges = boost::edges(mPoseGraph);
+	for(EdgeIterator it = edges.first; it != edges.second; ++it)
+	{
+		sensors.insert(mPoseGraph[*it].constraint->getSensorName());
+	}
+	return sensors;
 }
 
 const VertexObject BoostGraph::getVertex(IdType id) const

--- a/slam3d/graph/boost/BoostGraph.hpp
+++ b/slam3d/graph/boost/BoostGraph.hpp
@@ -77,7 +77,7 @@ namespace slam3d
 		 * @brief Gets a list of all vertices from given sensor.
 		 * @param sensor
 		 */
-		const VertexObjectList getVerticesFromSensor(const std::string& sensor) const;
+		const VertexObjectList getVerticesFromSensor(const StringSet& sensor) const;
 		
 		/**
 		 * @brief Gets a list of all vertices with a given measurement type.
@@ -91,14 +91,6 @@ namespace slam3d
 		 * @param range maximum number of steps to search from source
 		 */
 		const VertexObjectList getVerticesInRange(IdType source, unsigned range) const;
-
-		/**
-		 * @brief return lost of all Vertices in the graph (to accumulate a global map with different sources, i.e. not all sensor names are known)
-		 *
-		 * @return const VertexObjectList
-		 */
-		const VertexObjectList getAllVertices() const;
-
 
 		/**
 		 * @brief Gets a list of all edges from given sensor.

--- a/slam3d/graph/boost/BoostGraph.hpp
+++ b/slam3d/graph/boost/BoostGraph.hpp
@@ -77,7 +77,7 @@ namespace slam3d
 		 * @brief Gets a list of all vertices from given sensor.
 		 * @param sensor
 		 */
-		const VertexObjectList getVerticesFromSensor(const StringSet& sensor) const;
+		const VertexObjectList getVertices(const StringSet& sensor) const;
 		
 		/**
 		 * @brief Gets a list of all vertices with a given measurement type.
@@ -103,6 +103,19 @@ namespace slam3d
 		 * @param vertices
 		 */
 		const EdgeObjectList getEdges(const VertexObjectList& vertices) const;
+
+		/**
+		 * @brief Get a list of sensors that created vertices within the graph
+		 * @return list of sensor names 
+		 */
+		virtual const StringSet getVertexSensors() const;
+
+		/**
+		 * @brief Get a list of sensors that created edges within the graph
+		 * @return list of sensor names 
+		 */
+		virtual const StringSet getEdgeSensors() const;
+
 
 		/**
 		 * @brief Calculates the minimum number of edges between two vertices in the graph.

--- a/slam3d/graph/boost/BoostGraph.hpp
+++ b/slam3d/graph/boost/BoostGraph.hpp
@@ -50,13 +50,13 @@ namespace slam3d
 		 * @param iterations maximum number of iteration steps
 		 * @return true if optimization was successful
 		 */
-		bool optimize(unsigned iterations = 100);
+		bool optimize(unsigned iterations = 100) override;
 		
 		/**
 		 * @brief 
 		 * @param id
 		 */
-		const VertexObject getVertex(IdType id) const;
+		const VertexObject getVertex(IdType id) const override;
 		
 		/**
 		 * @brief 
@@ -64,57 +64,57 @@ namespace slam3d
 		 * @param target
 		 * @param sensor
 		 */
-		const EdgeObject getEdge(IdType source, IdType target, const std::string& sensor) const;
+		const EdgeObject getEdge(IdType source, IdType target, const std::string& sensor) const override;
 		
 		/**
 		 * @brief Get all outgoing edges from given source.
 		 * @param source
 		 * @throw std::out_of_range
 		 */
-		const EdgeObjectList getOutEdges(IdType source) const;
+		const EdgeObjectList getOutEdges(IdType source) const override;
 		
 		/**
 		 * @brief Gets a list of all vertices from given sensor.
 		 * @param sensor
 		 */
-		const VertexObjectList getVertices(const StringSet& sensor) const;
+		const VertexObjectList getVertices(const StringSet& sensor) const override;
 		
 		/**
 		 * @brief Gets a list of all vertices with a given measurement type.
 		 * @param sensor
 		 */
-		virtual const VertexObjectList getVerticesByType(const std::string& type) const;
+		virtual const VertexObjectList getVerticesByType(const std::string& type) const override;
 		
 		/**
 		 * @brief Serch for nodes by using breadth-first-search
 		 * @param source start search from this node
 		 * @param range maximum number of steps to search from source
 		 */
-		const VertexObjectList getVerticesInRange(IdType source, unsigned range) const;
+		const VertexObjectList getVerticesInRange(IdType source, unsigned range) const override;
 
 		/**
 		 * @brief Gets a list of all edges from given sensor.
 		 * @param sensor
 		 */
-		const EdgeObjectList getEdgesFromSensor(const std::string& sensor) const;
+		const EdgeObjectList getEdgesFromSensor(const std::string& sensor) const override;
 		
 		/**
 		 * @brief Get all connecting edges between given vertices.
 		 * @param vertices
 		 */
-		const EdgeObjectList getEdges(const VertexObjectList& vertices) const;
+		const EdgeObjectList getEdges(const VertexObjectList& vertices) const override;
 
 		/**
 		 * @brief Get a list of sensors that created vertices within the graph
 		 * @return list of sensor names 
 		 */
-		virtual const StringSet getVertexSensors() const;
+		virtual const StringSet getVertexSensors() const override;
 
 		/**
 		 * @brief Get a list of sensors that created edges within the graph
 		 * @return list of sensor names 
 		 */
-		virtual const StringSet getEdgeSensors() const;
+		virtual const StringSet getEdgeSensors() const override;
 
 
 		/**
@@ -122,14 +122,14 @@ namespace slam3d
 		 * @param source
 		 * @param target
 		 */
-		float calculateGraphDistance(IdType source, IdType target) const;
+		float calculateGraphDistance(IdType source, IdType target) const override;
 		
 		/**
 		 * @brief Write the current graph to a file (currently dot).
 		 * @details For larger graphs, this can take a very long time.
 		 * @param name filename without type ending
 		 */
-		void writeGraphToFile(const std::string &name);
+		void writeGraphToFile(const std::string &name) override;
 
 		/**
 		 * @brief Set the corrected pose for the vertex with the given ID.
@@ -141,39 +141,39 @@ namespace slam3d
 		 * @param id vertex to be changed
 		 * @param pose new corrected pose to be set
 		 */
-		void setCorrectedPose(IdType id, const Transform& pose);
+		void setCorrectedPose(IdType id, const Transform& pose) override;
 
 	protected:
 		/**
 		 * @brief Add the given VertexObject to the internal graph.
 		 * @param v
 		 */
-		void addVertex(const VertexObject& v);
+		void addVertex(const VertexObject& v) override;
 		
 		/**
 		 * @brief Set the given VertexObject to the internal graph.
 		 * @param id
 		 * @param v
 		 */
-		void setVertex(IdType id, const VertexObject& v);
+		void setVertex(IdType id, const VertexObject& v) override;
 		
 		/**
 		 * @brief Add the given EdgeObject to the internal graph.
 		 * @param e
 		 */
-		virtual void addEdge(const EdgeObject& e);
+		virtual void addEdge(const EdgeObject& e) override;
 		
 		/**
-		 * @brief 
+		 * @brief Remove an edge from the internal graph.
 		 * @param source
 		 * @param target
 		 * @param sensor
 		 */
-		virtual void removeEdge(IdType source, IdType target, const std::string& sensor);
+		virtual void removeEdge(IdType source, IdType target, const std::string& sensor) override;
 
 		
 		/**
-		 * @brief 
+		 * @brief Get the internal edge iterator for an edge.
 		 * @param source
 		 * @param target
 		 * @param sensor

--- a/slam3d/sensor/gdal/GpsPoseSensor.hpp
+++ b/slam3d/sensor/gdal/GpsPoseSensor.hpp
@@ -35,8 +35,8 @@ namespace slam3d
 		GpsPoseSensor(const std::string& n, Graph* g, Logger* l);
 		~GpsPoseSensor();
 
-		void handleNewVertex(IdType vertex);
-		Transform getPose(timeval stamp);
+		void handleNewVertex(IdType vertex) override;
+		Transform getPose(timeval stamp) override;
 		
 		void update(const timeval& t, const Position& p,
 		            const Covariance<3>& c, const Transform& sp);

--- a/slam3d/sensor/pcl/PointCloudSensor.hpp
+++ b/slam3d/sensor/pcl/PointCloudSensor.hpp
@@ -124,7 +124,7 @@ namespace slam3d
 		 * @param pose origin of the accumulated pointcloud
 		 * @throw BadMeasurementType
 		 */		
-		Measurement::Ptr createCombinedMeasurement(const VertexObjectList& vertices, Transform pose) const;
+		Measurement::Ptr createCombinedMeasurement(const VertexObjectList& vertices, Transform pose) const override;
 		
 		/**
 		 * @brief Create an ICP constraint between two point clouds.

--- a/slam3d/sensor/pcl/PointCloudSensor.hpp
+++ b/slam3d/sensor/pcl/PointCloudSensor.hpp
@@ -136,7 +136,7 @@ namespace slam3d
 		virtual Constraint::Ptr createConstraint(const Measurement::Ptr& source,
 		                                         const Measurement::Ptr& target,
 		                                         const Transform& odometry,
-		                                         bool loop);
+		                                         bool loop) override;
 		
 		/**
 		 * @brief Sets parameters for the internal pointcloud registration.

--- a/slam3d/sensor/pointmatcher/Scan2DSensor.hpp
+++ b/slam3d/sensor/pointmatcher/Scan2DSensor.hpp
@@ -82,7 +82,7 @@ namespace slam3d
 		 * @param pose origin of the accumulated pointcloud
 		 * @throw BadMeasurementType
 		 */		
-		Measurement::Ptr createCombinedMeasurement(const VertexObjectList& vertices, Transform pose) const;
+		Measurement::Ptr createCombinedMeasurement(const VertexObjectList& vertices, Transform pose) const override;
 
 		/**
 		 * @brief 

--- a/slam3d/solver/g2o/G2oSolver.hpp
+++ b/slam3d/solver/g2o/G2oSolver.hpp
@@ -42,18 +42,18 @@ namespace slam3d
 		G2oSolver(Logger* logger);
 		~G2oSolver();
 		
-		void addVertex(IdType id, const Transform& pose);
-		void addEdgeSE3(IdType source, IdType target, SE3Constraint::Ptr se3);
-		void addEdgeGravity(IdType vertex, GravityConstraint::Ptr grav);
-		void addEdgePosition(IdType vertex, PositionConstraint::Ptr pos);
-		void addEdgeOrientation(IdType vertex, OrientationConstraint::Ptr orient);
-		void addEdgePose(IdType vertex, PoseConstraint::Ptr pose);
-		void setFixed(IdType id);
-		bool compute(unsigned iterations);
-		void clear();
-		void saveGraph(std::string filename);
+		void addVertex(IdType id, const Transform& pose) override;
+		void addEdgeSE3(IdType source, IdType target, SE3Constraint::Ptr se3) override;
+		void addEdgeGravity(IdType vertex, GravityConstraint::Ptr grav) override;
+		void addEdgePosition(IdType vertex, PositionConstraint::Ptr pos) override;
+		void addEdgeOrientation(IdType vertex, OrientationConstraint::Ptr orient) override;
+		void addEdgePose(IdType vertex, PoseConstraint::Ptr pose) override;
+		void setFixed(IdType id) override;
+		bool compute(unsigned iterations) override;
+		void clear() override;
+		void saveGraph(std::string filename) override;
 		
-		IdPoseVector getCorrections();
+		IdPoseVector getCorrections() override;
 		
 	protected:
 		IdPoseVector mCorrections;


### PR DESCRIPTION
This adds some consistency in how to get vertices from multiple sensors instead of only one. `Graph::getVertices(set<string> sensors)` now gets vertices from a set of sensors. If left out, returns all vertices.
`Graph::getAllVertices()` was removed in favor of `Graph::getVertices()`. `Graph::getVerticesFromSensor(string sensor)` stays around for backward compatibility and just calls `Graph::getVertex()`.

@planthaber The new `Graph::getVertex()` will have to be implemented in slam3d_database.