### PR TITLE
add jsoncpp guard for 22.04

### DIFF
--- a/slam3d-dependencies.cmake
+++ b/slam3d-dependencies.cmake
@@ -7,7 +7,10 @@ if (NOT TARGET Eigen3::Eigen)
 		INTERFACE_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIR})
 endif ()
 
-find_package(jsoncpp)
+if (NOT TARGET JsonCpp::JsonCpp) # guard to fix faulty jsoncpp .cmake in ubuntu 22.04
+	find_package(jsoncpp)
+endif()
+
 if(TARGET JsonCpp::JsonCpp)
 	set(JSONCPP_TARGET JsonCpp::JsonCpp)
 else()


### PR DESCRIPTION
In Ubuntu 20.04 fond_package(jsoncpp) cannot be called multiple times.

Here, when using addons (like slam3d_databases) that depend on slem3d, it woulf be called more often